### PR TITLE
Erro na RotaView.php

### DIFF
--- a/view/RotaView.php
+++ b/view/RotaView.php
@@ -82,7 +82,7 @@
 		<?php 
 			require_once '../includes/mensagens.php';
 
-			if(count($rotas) > 0){
+			if($rotas != null){
 
 				foreach($rotas as $rota){ 
 


### PR DESCRIPTION
Warning: count(): Parameter must be an array or an object that implements Countable in C:\server\htdocs\sistema-rodoviaria\view\RotaView.php on line 85.

Estava aparecendo esse erro ao tentar agendar uma Viajem, a variável $rotas estava recebendo NULL e por isso o contador não estava funcionando, apenas modifiquei para quando for diferente de NULL em vez de maior que 0.

Agora não está mais aparecendo mensagem de erro quando não tem nenhuma rota marcada, apenas o Card com a mensagem prevista.
 ;)